### PR TITLE
Fix bug

### DIFF
--- a/src/ripple/app/tx/impl/MPTokenAuthorize.cpp
+++ b/src/ripple/app/tx/impl/MPTokenAuthorize.cpp
@@ -168,7 +168,7 @@ MPTokenAuthorize::doApply()
         }
 
         // A potential holder wants to authorize/hold a mpt, the ledger must:
-        //      - add the new mptokenKey to both the owner and mpt directries
+        //      - add the new mptokenKey to the owner directory
         //      - create the MPToken object for the holder
         std::uint32_t const uOwnerCount = sleAcct->getFieldU32(sfOwnerCount);
         XRPAmount const reserveCreate(

--- a/src/ripple/app/tx/impl/MPTokenAuthorize.cpp
+++ b/src/ripple/app/tx/impl/MPTokenAuthorize.cpp
@@ -61,12 +61,14 @@ MPTokenAuthorize::preclaim(PreclaimContext const& ctx)
     //
     // Note: `accountID` is holder's account
     //       `holderID` is NOT used
-    if (!holderID){
-        std::shared_ptr<SLE const> sleMpt =
-            ctx.view.read(keylet::mptoken(ctx.tx[sfMPTokenIssuanceID], accountID));
+    if (!holderID)
+    {
+        std::shared_ptr<SLE const> sleMpt = ctx.view.read(
+            keylet::mptoken(ctx.tx[sfMPTokenIssuanceID], accountID));
 
-        // There is an edge case where holder deletes MPT after issuance has already been destroyed. 
-        // So we must check for unauthorize before fetching the MPTIssuance object(since it doesn't exist)
+        // There is an edge case where holder deletes MPT after issuance has
+        // already been destroyed. So we must check for unauthorize before
+        // fetching the MPTIssuance object(since it doesn't exist)
 
         // if holder wants to delete/unauthorize a mpt
         if (txFlags & tfMPTUnauthorize)
@@ -76,17 +78,17 @@ MPTokenAuthorize::preclaim(PreclaimContext const& ctx)
 
             if ((*sleMpt)[sfMPTAmount] != 0)
                 return tecHAS_OBLIGATIONS;
-            
+
             return tesSUCCESS;
         }
 
         // Now test when the holder wants to hold/create/authorize a new MPT
-        sleMptIssuance =         
+        sleMptIssuance =
             ctx.view.read(keylet::mptIssuance(ctx.tx[sfMPTokenIssuanceID]));
 
         if (!sleMptIssuance)
             return tecOBJECT_NOT_FOUND;
-        
+
         if (accountID == (*sleMptIssuance)[sfIssuer])
             return temMALFORMED;
 
@@ -143,7 +145,8 @@ MPTokenAuthorize::doApply()
     // If the account that submitted the tx is a holder
     // Note: `account_` is holder's account
     //       `holderID` is NOT used
-    if (!holderID){
+    if (!holderID)
+    {
         // When a holder wants to unauthorize/delete a MPT, the ledger must
         //      - delete mptokenKey from both owner and mpt directories
         //      - delete the MPToken
@@ -173,7 +176,7 @@ MPTokenAuthorize::doApply()
         std::uint32_t const uOwnerCount = sleAcct->getFieldU32(sfOwnerCount);
         XRPAmount const reserveCreate(
             (uOwnerCount < 2) ? XRPAmount(beast::zero)
-                            : view().fees().accountReserve(uOwnerCount + 1));
+                              : view().fees().accountReserve(uOwnerCount + 1));
 
         if (mPriorBalance < reserveCreate)
             return tecINSUFFICIENT_RESERVE;
@@ -199,7 +202,8 @@ MPTokenAuthorize::doApply()
         return tesSUCCESS;
     }
 
-    std::shared_ptr<SLE const> sleMptIssuance = view().read(keylet::mptIssuance(mptIssuanceID));
+    std::shared_ptr<SLE const> sleMptIssuance =
+        view().read(keylet::mptIssuance(mptIssuanceID));
     if (!sleMptIssuance)
         return tecINTERNAL;
 
@@ -208,12 +212,11 @@ MPTokenAuthorize::doApply()
     //       `holderID` is holder's account
     if (account_ != (*sleMptIssuance)[sfIssuer])
         return tecINTERNAL;
-    
+
     if (!holderID)
         return tecINTERNAL;
 
-    auto const sleMpt =
-        view().peek(keylet::mptoken(mptIssuanceID, *holderID));
+    auto const sleMpt = view().peek(keylet::mptoken(mptIssuanceID, *holderID));
     if (!sleMpt)
         return tecINTERNAL;
 

--- a/src/ripple/app/tx/impl/MPTokenAuthorize.cpp
+++ b/src/ripple/app/tx/impl/MPTokenAuthorize.cpp
@@ -46,17 +46,61 @@ MPTokenAuthorize::preflight(PreflightContext const& ctx)
 TER
 MPTokenAuthorize::preclaim(PreclaimContext const& ctx)
 {
-    auto const sleMptIssuance =
-        ctx.view.read(keylet::mptIssuance(ctx.tx[sfMPTokenIssuanceID]));
-    if (!sleMptIssuance)
-        return tecOBJECT_NOT_FOUND;
-
     auto const accountID = ctx.tx[sfAccount];
     auto const txFlags = ctx.tx.getFlags();
     auto const holderID = ctx.tx[~sfMPTokenHolder];
 
     if (holderID && !(ctx.view.exists(keylet::account(*holderID))))
         return tecNO_DST;
+
+    std::shared_ptr<SLE const> sleMptIssuance;
+
+    // if non-issuer account submits this tx, then they are trying either:
+    // 1. Unauthorize/delete MPToken
+    // 2. Use/create MPToken
+    //
+    // Note: `accountID` is holder's account
+    //       `holderID` is NOT used
+    if (!holderID){
+        std::shared_ptr<SLE const> sleMpt =
+            ctx.view.read(keylet::mptoken(ctx.tx[sfMPTokenIssuanceID], accountID));
+
+        // There is an edge case where holder deletes MPT after issuance has already been destroyed. 
+        // So we must check for unauthorize before fetching the MPTIssuance object(since it doesn't exist)
+
+        // if holder wants to delete/unauthorize a mpt
+        if (txFlags & tfMPTUnauthorize)
+        {
+            if (!sleMpt)
+                return tecNO_ENTRY;
+
+            if ((*sleMpt)[sfMPTAmount] != 0)
+                return tecHAS_OBLIGATIONS;
+            
+            return tesSUCCESS;
+        }
+
+        // Now test when the holder wants to hold/create/authorize a new MPT
+        sleMptIssuance =         
+            ctx.view.read(keylet::mptIssuance(ctx.tx[sfMPTokenIssuanceID]));
+
+        if (!sleMptIssuance)
+            return tecOBJECT_NOT_FOUND;
+        
+        if (accountID == (*sleMptIssuance)[sfIssuer])
+            return temMALFORMED;
+
+        // if holder wants to use and create a mpt
+        if (sleMpt)
+            return tecMPTOKEN_EXISTS;
+
+        return tesSUCCESS;
+    }
+
+    sleMptIssuance =
+        ctx.view.read(keylet::mptIssuance(ctx.tx[sfMPTokenIssuanceID]));
+    if (!sleMptIssuance)
+        return tecOBJECT_NOT_FOUND;
 
     std::uint32_t const mptIssuanceFlags = sleMptIssuance->getFieldU32(sfFlags);
 
@@ -67,47 +111,20 @@ MPTokenAuthorize::preclaim(PreclaimContext const& ctx)
     //
     // Note: `accountID` is issuer's account
     //       `holderID` is holder's account
-    if (accountID == (*sleMptIssuance)[sfIssuer])
-    {
-        // If tx is submitted by issuer, it only applies for MPT with
-        // lsfMPTRequireAuth set
-        if (!(mptIssuanceFlags & lsfMPTRequireAuth))
-            return tecNO_AUTH;
-
-        if (!holderID)
-            return temMALFORMED;
-
-        if (!ctx.view.exists(
-                keylet::mptoken(ctx.tx[sfMPTokenIssuanceID], *holderID)))
-            return tecNO_ENTRY;
-
-        return tesSUCCESS;
-    }
-
-    // if non-issuer account submits this tx, then they are trying either:
-    // 1. Unauthorize/delete MPToken
-    // 2. Use/create MPToken
-    //
-    // Note: `accountID` is holder's account
-    //       `holderID` is NOT used
-    if (holderID)
+    if (accountID != (*sleMptIssuance)[sfIssuer])
         return temMALFORMED;
 
-    std::shared_ptr<SLE const> sleMpt =
-        ctx.view.read(keylet::mptoken(ctx.tx[sfMPTokenIssuanceID], accountID));
+    if (!holderID)
+        return temMALFORMED;
 
-    // if holder wants to delete/unauthorize a mpt
-    if (txFlags & tfMPTUnauthorize)
-    {
-        if (!sleMpt)
-            return tecNO_ENTRY;
+    // If tx is submitted by issuer, it only applies for MPT with
+    // lsfMPTRequireAuth set
+    if (!(mptIssuanceFlags & lsfMPTRequireAuth))
+        return tecNO_AUTH;
 
-        if ((*sleMpt)[sfMPTAmount] != 0)
-            return tecHAS_OBLIGATIONS;
-    }
-    // if holder wants to use and create a mpt
-    else if (sleMpt)
-        return tecMPTOKEN_EXISTS;
+    if (!ctx.view.exists(
+            keylet::mptoken(ctx.tx[sfMPTokenIssuanceID], *holderID)))
+        return tecNO_ENTRY;
 
     return tesSUCCESS;
 }
@@ -116,10 +133,6 @@ TER
 MPTokenAuthorize::doApply()
 {
     auto const mptIssuanceID = ctx_.tx[sfMPTokenIssuanceID];
-    auto const sleMptIssuance = view().read(keylet::mptIssuance(mptIssuanceID));
-    if (!sleMptIssuance)
-        return tecINTERNAL;
-
     auto const sleAcct = view().peek(keylet::account(account_));
     if (!sleAcct)
         return tecINTERNAL;
@@ -127,96 +140,99 @@ MPTokenAuthorize::doApply()
     auto const holderID = ctx_.tx[~sfMPTokenHolder];
     auto const txFlags = ctx_.tx.getFlags();
 
-    // If the account that submitted this tx is the issuer of the MPT
-    // Note: `account_` is issuer's account
-    //       `holderID` is holder's account
-    if (account_ == (*sleMptIssuance)[sfIssuer])
-    {
-        if (!holderID)
-            return tecINTERNAL;
-
-        auto const sleMpt =
-            view().peek(keylet::mptoken(mptIssuanceID, *holderID));
-        if (!sleMpt)
-            return tecINTERNAL;
-
-        std::uint32_t const flagsIn = sleMpt->getFieldU32(sfFlags);
-        std::uint32_t flagsOut = flagsIn;
-
-        // Issuer wants to unauthorize the holder, unset lsfMPTAuthorized on
-        // their MPToken
-        if (txFlags & tfMPTUnauthorize)
-            flagsOut &= ~lsfMPTAuthorized;
-        // Issuer wants to authorize a holder, set lsfMPTAuthorized on their
-        // MPToken
-        else
-            flagsOut |= lsfMPTAuthorized;
-
-        if (flagsIn != flagsOut)
-            sleMpt->setFieldU32(sfFlags, flagsOut);
-
-        view().update(sleMpt);
-        return tesSUCCESS;
-    }
-
     // If the account that submitted the tx is a holder
     // Note: `account_` is holder's account
     //       `holderID` is NOT used
-    if (holderID)
-        return tecINTERNAL;
+    if (!holderID){
+        // When a holder wants to unauthorize/delete a MPT, the ledger must
+        //      - delete mptokenKey from both owner and mpt directories
+        //      - delete the MPToken
+        if (txFlags & tfMPTUnauthorize)
+        {
+            auto const mptokenKey = keylet::mptoken(mptIssuanceID, account_);
+            auto const sleMpt = view().peek(mptokenKey);
+            if (!sleMpt)
+                return tecINTERNAL;
 
-    // When a holder wants to unauthorize/delete a MPT, the ledger must
-    //      - delete mptokenKey from both owner and mpt directories
-    //      - delete the MPToken
-    if (txFlags & tfMPTUnauthorize)
-    {
+            if (!view().dirRemove(
+                    keylet::ownerDir(account_),
+                    (*sleMpt)[sfOwnerNode],
+                    sleMpt->key(),
+                    false))
+                return tecINTERNAL;
+
+            adjustOwnerCount(view(), sleAcct, -1, j_);
+
+            view().erase(sleMpt);
+            return tesSUCCESS;
+        }
+
+        // A potential holder wants to authorize/hold a mpt, the ledger must:
+        //      - add the new mptokenKey to both the owner and mpt directries
+        //      - create the MPToken object for the holder
+        std::uint32_t const uOwnerCount = sleAcct->getFieldU32(sfOwnerCount);
+        XRPAmount const reserveCreate(
+            (uOwnerCount < 2) ? XRPAmount(beast::zero)
+                            : view().fees().accountReserve(uOwnerCount + 1));
+
+        if (mPriorBalance < reserveCreate)
+            return tecINSUFFICIENT_RESERVE;
+
         auto const mptokenKey = keylet::mptoken(mptIssuanceID, account_);
-        auto const sleMpt = view().peek(mptokenKey);
-        if (!sleMpt)
-            return tecINTERNAL;
 
-        if (!view().dirRemove(
-                keylet::ownerDir(account_),
-                (*sleMpt)[sfOwnerNode],
-                sleMpt->key(),
-                false))
-            return tecINTERNAL;
+        auto const ownerNode = view().dirInsert(
+            keylet::ownerDir(account_), mptokenKey, describeOwnerDir(account_));
 
-        adjustOwnerCount(view(), sleAcct, -1, j_);
+        if (!ownerNode)
+            return tecDIR_FULL;
 
-        view().erase(sleMpt);
+        auto mptoken = std::make_shared<SLE>(mptokenKey);
+        (*mptoken)[sfAccount] = account_;
+        (*mptoken)[sfMPTokenIssuanceID] = mptIssuanceID;
+        (*mptoken)[sfFlags] = 0;
+        (*mptoken)[sfOwnerNode] = *ownerNode;
+        view().insert(mptoken);
+
+        // Update owner count.
+        adjustOwnerCount(view(), sleAcct, 1, j_);
+
         return tesSUCCESS;
     }
 
-    // A potential holder wants to authorize/hold a mpt, the ledger must:
-    //      - add the new mptokenKey to both the owner and mpt directries
-    //      - create the MPToken object for the holder
-    std::uint32_t const uOwnerCount = sleAcct->getFieldU32(sfOwnerCount);
-    XRPAmount const reserveCreate(
-        (uOwnerCount < 2) ? XRPAmount(beast::zero)
-                          : view().fees().accountReserve(uOwnerCount + 1));
+    std::shared_ptr<SLE const> sleMptIssuance = view().read(keylet::mptIssuance(mptIssuanceID));
+    if (!sleMptIssuance)
+        return tecINTERNAL;
 
-    if (mPriorBalance < reserveCreate)
-        return tecINSUFFICIENT_RESERVE;
+    // If the account that submitted this tx is the issuer of the MPT
+    // Note: `account_` is issuer's account
+    //       `holderID` is holder's account
+    if (account_ != (*sleMptIssuance)[sfIssuer])
+        return tecINTERNAL;
+    
+    if (!holderID)
+        return tecINTERNAL;
 
-    auto const mptokenKey = keylet::mptoken(mptIssuanceID, account_);
+    auto const sleMpt =
+        view().peek(keylet::mptoken(mptIssuanceID, *holderID));
+    if (!sleMpt)
+        return tecINTERNAL;
 
-    auto const ownerNode = view().dirInsert(
-        keylet::ownerDir(account_), mptokenKey, describeOwnerDir(account_));
+    std::uint32_t const flagsIn = sleMpt->getFieldU32(sfFlags);
+    std::uint32_t flagsOut = flagsIn;
 
-    if (!ownerNode)
-        return tecDIR_FULL;
+    // Issuer wants to unauthorize the holder, unset lsfMPTAuthorized on
+    // their MPToken
+    if (txFlags & tfMPTUnauthorize)
+        flagsOut &= ~lsfMPTAuthorized;
+    // Issuer wants to authorize a holder, set lsfMPTAuthorized on their
+    // MPToken
+    else
+        flagsOut |= lsfMPTAuthorized;
 
-    auto mptoken = std::make_shared<SLE>(mptokenKey);
-    (*mptoken)[sfAccount] = account_;
-    (*mptoken)[sfMPTokenIssuanceID] = mptIssuanceID;
-    (*mptoken)[sfFlags] = 0;
-    (*mptoken)[sfOwnerNode] = *ownerNode;
-    view().insert(mptoken);
+    if (flagsIn != flagsOut)
+        sleMpt->setFieldU32(sfFlags, flagsOut);
 
-    // Update owner count.
-    adjustOwnerCount(view(), sleAcct, 1, j_);
-
+    view().update(sleMpt);
     return tesSUCCESS;
 }
 

--- a/src/test/app/MPToken_test.cpp
+++ b/src/test/app/MPToken_test.cpp
@@ -242,7 +242,7 @@ class MPToken_test : public beast::unit_test::suite
                 {.account = &bob, .holder = &bob, .err = temMALFORMED});
 
             // alice tries to hold onto her own token
-            mptAlice.authorize({.account= &alice, .err = temMALFORMED});
+            mptAlice.authorize({.account = &alice, .err = temMALFORMED});
 
             // alice tries to authorize herself
             mptAlice.authorize({.holder = &alice, .err = temMALFORMED});
@@ -276,7 +276,8 @@ class MPToken_test : public beast::unit_test::suite
             // bob deletes/unauthorizes his MPToken
             mptAlice.authorize({.account = &bob, .flags = tfMPTUnauthorize});
 
-            // bob receives error when he tries to delete his MPToken that has already been deleted
+            // bob receives error when he tries to delete his MPToken that has
+            // already been deleted
             mptAlice.authorize(
                 {.account = &bob,
                  .holderCount = 0,
@@ -434,7 +435,7 @@ class MPToken_test : public beast::unit_test::suite
             MPTTester mptAlice(env, alice, {.holders = {&bob}});
 
             mptAlice.create({.ownerCount = 1});
-            
+
             // bob creates a mptoken
             mptAlice.authorize({.account = &bob, .holderCount = 1});
 
@@ -444,7 +445,8 @@ class MPToken_test : public beast::unit_test::suite
             // alice deletes her issuance
             mptAlice.destroy({.ownerCount = 0});
 
-            // bob can delete his mptoken even though issuance is no longer existent
+            // bob can delete his mptoken even though issuance is no longer
+            // existent
             mptAlice.authorize(
                 {.account = &bob, .holderCount = 0, .flags = tfMPTUnauthorize});
         }

--- a/src/test/app/MPToken_test.cpp
+++ b/src/test/app/MPToken_test.cpp
@@ -273,8 +273,10 @@ class MPToken_test : public beast::unit_test::suite
                 mptAlice.pay(bob, alice, 100);
             }
 
+            // bob deletes/unauthorizes his MPToken
             mptAlice.authorize({.account = &bob, .flags = tfMPTUnauthorize});
 
+            // bob receives error when he tries to delete his MPToken that has already been deleted
             mptAlice.authorize(
                 {.account = &bob,
                  .holderCount = 0,


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change
Fixes a bug where a holder is unable to delete/unauthorize their MPToken when the MPTokenIssuance has already been destroyed. This is because, in the `MPTokenAuthorize` transaction,  we check the existence of the MPTokenIssuance object before doing the code that checks for unauthorize/deletes, which would always return error if  a MPTokenIssuance doesn't exist. Therefore, this refactor changes the order of if-statement logic
<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
